### PR TITLE
clean up warning

### DIFF
--- a/bin/license
+++ b/bin/license
@@ -4,7 +4,7 @@ use Software::License;
 
 sub MAIN (Str:D $license_shortname, Str:D $owner_name, $year?)
 {
-  my $license = Software::License.new, 'Constructor';
+  my $license = Software::License.new;
 
   if $year
   {


### PR DESCRIPTION
I think that line must have been cut and pasted from the test, where 'Constructor' was the name of the test:

ok my $license = Software::License.new, 'Constructor';

however it generates a warning message in this context:

Useless use of constant string "Constructor" in sink context (lines 7, 7)